### PR TITLE
티켓 구매 및 처리 예외 케이스 추가

### DIFF
--- a/src/main/java/com/theater/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/theater/domain/ticket/service/TicketService.java
@@ -9,6 +9,7 @@ import com.theater.domain.ticket.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.management.AttributeNotFoundException;
 import java.util.List;
 
 @Service
@@ -19,11 +20,12 @@ public class TicketService {
     private final MemberRepository memberRepository;
     private final ScheduleRepository scheduleRepository;
 
-    public Ticket buy(String memberId, Ticket ticket) {
+    public Ticket buy(String memberId, Ticket ticket) throws AttributeNotFoundException {
         Member member = memberRepository.findById(memberId);
         int money = member.getMoney();
 
         Schedule schedule = scheduleRepository.findByKey(ticket.getScheduleKey());
+        if (schedule == null) throw new AttributeNotFoundException("일치하는 상영일정이 없습니다.");
         int price = schedule.getPrice();
 
         String seatState = schedule.getSeatState();

--- a/src/main/java/com/theater/web/exhandler/TicketControllerExceptionAdvice.java
+++ b/src/main/java/com/theater/web/exhandler/TicketControllerExceptionAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.management.AttributeNotFoundException;
 import javax.security.sasl.AuthenticationException;
 
 @RestControllerAdvice(assignableTypes = {TicketController.class}) //TicketController에서 예외가 발생하면 모두 이곳으로 옴
@@ -28,14 +29,14 @@ public class TicketControllerExceptionAdvice {
             message = e.getMessage();
             status = HttpStatus.BAD_REQUEST;
             errorCode = -500;
-        } else if (e instanceof MissingServletRequestParameterException) {
-            message = "쿼리 파라미터 all은 필수값입니다.";
+        } else if (e instanceof AttributeNotFoundException) {
+            message = e.getMessage();
             status = HttpStatus.BAD_REQUEST;
-            errorCode = -511;
+            errorCode = -501;
         } else if (e instanceof IllegalArgumentException) {
             message = e.getMessage();
             status = HttpStatus.BAD_REQUEST;
-            errorCode = -512;
+            errorCode = -513;
         } else { //위의 조건문에서 처리하지 못한, 알 수 없는 에러가 발생한 경우 Http 상태코드=500, errorCode=-599 로 반환
             message = e.getMessage();
             status = HttpStatus.INTERNAL_SERVER_ERROR;

--- a/src/main/java/com/theater/web/ticket/TicketController.java
+++ b/src/main/java/com/theater/web/ticket/TicketController.java
@@ -2,7 +2,6 @@ package com.theater.web.ticket;
 
 import com.theater.domain.ticket.Ticket;
 import com.theater.domain.ticket.dto.TicketRegister;
-import com.theater.domain.ticket.dto.TicketShowDto;
 import com.theater.domain.ticket.service.TicketService;
 import com.theater.web.argumentresolver.Login;
 import com.theater.web.responsedata.ResponseResult;
@@ -13,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import javax.management.AttributeNotFoundException;
 import java.util.List;
 
 @RestController
@@ -28,7 +28,7 @@ public class TicketController {
     private final TicketRegister register;
 
     @PostMapping //티켓 구매(에러 발생시 errorCode: -500번대)
-    public ResponseResult buyTicket(@Login String memberId, @RequestBody Ticket form) {
+    public ResponseResult buyTicket(@Login String memberId, @RequestBody Ticket form) throws AttributeNotFoundException {
 
         Ticket ticket = ticketService.buy(memberId, form); //form에 맞는 티켓을 생성 후 구매
         if (ticket == null) { //회원의 보유 금액이 부족하거나 선택한 좌석이 이미 예약된 경우 오류 반환
@@ -42,18 +42,14 @@ public class TicketController {
 
     @GetMapping// 자신의 티켓 조회. 쿼리 파라미터에 따라 조회 방식이 달라짐(에러 발생시 errorCode: -510번대)
     public ResponseResult showTickets(@Login String memberId,
-                                      @RequestParam Boolean all, //all(true/false): 티켓 전체 조회인지 아닌지 알려주는 필수 쿼리 파라미터
                                       @RequestParam(required = false) Integer ticket,
                                       @RequestParam(required = false) Integer schedule) {
 
-        if (all == true) { //내 티켓 전체를 조회하는 경우
+        if (ticket == null && schedule == null) { //1. 내 티켓 전체를 조회하는 경우
             List<Ticket> ticketList = ticketService.findMyAllTickets(memberId);
             //조회한 티켓을 사용자가 보기 용이한 스펙으로 변경하여 반환 ( register.changeToShowList() )
             return new TicketResult("모든 내 티켓 조회 성공", register.changeToShowList(ticketList));
-        }
-
-        //특정 티켓만 조회하는 경우
-        if (ticket != null) { //1. 티켓 번호로 조회
+        } else if (ticket != null && schedule == null) { //2. 특정 티켓만 티켓 번호로 조회하는 경우
             Ticket myTicket = ticketService.findMyTicket(ticket);
             //티켓 번호에 해당하는 티켓이 없거나 해당 티켓의 회원아이디가 내 아이디와 다른 경우 오류 반환
             if (myTicket == null || !myTicket.getMemberId().equals(memberId)) {
@@ -62,8 +58,7 @@ public class TicketController {
             }
             //조회한 티켓을 사용자가 보기 용이한 스펙으로 변경하여 반환 ( register.changeToShow() )
             return new TicketResult("티켓 번호로 내 티켓 조회 성공", register.changeToShow(myTicket));
-        }
-        if (schedule != null) { //2. 스케줄 번호와 내 아이디로 조회
+        } else if (ticket == null && schedule != null) { //3. 특정 티켓만 스케줄 번호와 내 아이디로 조회하는 경우
             Ticket myTicket = ticketService.findMyTicket(memberId, schedule);
             //그 상영일정에 해당하는 티켓이 없거나 해당 티켓의 회원아이디가 내 아이디와 다른 경우 오류 반환
             if (myTicket == null || !myTicket.getMemberId().equals(memberId)) {
@@ -72,9 +67,9 @@ public class TicketController {
             }
             //조회한 티켓을 사용자가 보기 용이한 스펙으로 변경하여 반환 ( register.changeToShow() )
             return new TicketResult("아이디와 상영일정으로 내 티켓 조회 성공", register.changeToShow(myTicket));
+        } else { //4. 위의 로직에서 반환이 되지 않고 이곳까지 진행되면 정해놓은 쿼리 파라미터 조건에 부합하지 않았다는 것. 이때는 예외 발생시킴
+            throw new IllegalArgumentException("쿼리 파라미터 조건이 일치하지 않음");
         }
-        //위의 로직에서 반환이 되지 않고 이곳까지 진행되면 쿼리 파라미터 조건에 부합하지 않았다는 것. 이때는 예외 발생시킴
-        throw new IllegalArgumentException("쿼리 파라미터 관련 조건이 일치하지 않음");
     }
 
     @DeleteMapping("/{ticketKey}") //티켓 환불(에러 발생시 errorCode: -520번대)


### PR DESCRIPTION
다음의 경우들을 반영함

1. 티켓 구매 시 상영일정 정보를 찾을 수 없으면 예외 반환
2. 티켓 조회 API의 URL에서 add 쿼리 파라미터 삭제